### PR TITLE
Remove broken link to requirements page

### DIFF
--- a/en/step_4.md
+++ b/en/step_4.md
@@ -6,8 +6,6 @@ If you want to know more about using JSON and the RESTful API of the Raspberry P
 
 - Open a new Python shell by clicking on **Menu** > **Programming** > **Python 3 (IDLE)**. Then click **File** > **New File** to start a new script.
 
-- To begin, you'll need to import a Python module. If you haven't installed it yet, you can find details on the [requirements page](https://projects.raspberrypi.org/en/projects/mapping-the-weather/requirements).
-
 
     ``` python
     from requests import get


### PR DESCRIPTION
Since going over to the new format, the link to the requirements page now takes you to the page that tells you that you have completed the resource.  Now that there are "steps", it probably best to remove this link entirely.  Linked to #1  