### PR TITLE
Add improved escaping explanation in new worksheet format

### DIFF
--- a/en/step_4.md
+++ b/en/step_4.md
@@ -57,7 +57,7 @@ If you want to know more about using JSON and the RESTful API of the Raspberry P
     stations['items'][5]['weather_stn_long']
     ```
 
-- Add three list comprehensions to your Python file to fetch all the longitude and latitude values along with the names of the weather stations. These commands iterate over the JSON data and extract each of the longitudes, latitudes, and names and place them in separate lists.
+- Add three list comprehensions to your Python file to fetch all the longitude and latitude values along with the names of the weather stations. These commands iterate over the JSON data and extract each of the longitudes, latitudes, and names and place them in separate lists. When school's register their weather station names, they can use characters, especially punctuation like apostrophes, that may cause problems when used within HTML tags. Converting these characters to a safe format is called *escaping* and the Python html library has a handy function for just this job.
 
     ``` python
     lons = [station['weather_stn_long'] for station in stations['items']]


### PR DESCRIPTION
66b45eea14e7cee6921b74e9e9a2745597e7ebd0 never made it into the new worksheet format (and it appears to have been lost in the old format too).